### PR TITLE
Add Settings UI and Hint hiding if arguments are provided.

### DIFF
--- a/src/main/java/com.github.umbreon22.inlayenumordinals/EnumOrdinalHintCollector.java
+++ b/src/main/java/com.github.umbreon22.inlayenumordinals/EnumOrdinalHintCollector.java
@@ -1,5 +1,6 @@
 package com.github.umbreon22.inlayenumordinals;
 
+import com.github.umbreon22.inlayenumordinals.settings.EnumOrdinalSettingsState;
 import com.intellij.codeInsight.hints.FactoryInlayHintsCollector;
 import com.intellij.codeInsight.hints.InlayHintsSink;
 import com.intellij.codeInsight.hints.presentation.InlayPresentation;
@@ -14,24 +15,27 @@ import java.util.List;
 
 public class EnumOrdinalHintCollector extends FactoryInlayHintsCollector {
 
-	public EnumOrdinalHintCollector(@NotNull Editor editor) {
+	private final EnumOrdinalSettingsState settings;
+
+	public EnumOrdinalHintCollector(@NotNull Editor editor, EnumOrdinalSettingsState settings) {
 		super(editor);
+		this.settings = settings;
 	}
 
 	@Override
 	public boolean collect(@NotNull PsiElement element, @NotNull Editor editor, @NotNull InlayHintsSink inlayHintsSink) {
 		if(element instanceof PsiJavaFile) {
 			PsiJavaFile file = (PsiJavaFile) element;
-			List<PsiElement> elements = collectEnumElements(file);
+			List<PsiElement> elements = collectEnumElements(file, settings.getHideHintIfArguments());
 			elements.forEach(elem -> addOrdinalHint(elem, inlayHintsSink));
 		}
 		return true;
 	}
 
-	private static List<PsiElement> collectEnumElements(PsiJavaFile file) {
+	private static List<PsiElement> collectEnumElements(PsiJavaFile file, boolean hideHintIfArguments) {
 		List<PsiElement> elements = new LinkedList<>();
 		PsiTreeUtil.processElements(file, element -> {
-			if(PsiEnumUtil.isEnum(element)) {
+			if(PsiEnumUtil.isEnum(element, hideHintIfArguments)) {
 				elements.add(element);
 			}
 			return true;

--- a/src/main/java/com.github.umbreon22.inlayenumordinals/EnumOrdinalHintProvider.java
+++ b/src/main/java/com.github.umbreon22.inlayenumordinals/EnumOrdinalHintProvider.java
@@ -1,10 +1,10 @@
 package com.github.umbreon22.inlayenumordinals;
 
+import com.github.umbreon22.inlayenumordinals.settings.EnumOrdinalSettingsState;
 import com.intellij.codeInsight.hints.ImmediateConfigurable;
 import com.intellij.codeInsight.hints.InlayHintsCollector;
 import com.intellij.codeInsight.hints.InlayHintsProvider;
 import com.intellij.codeInsight.hints.InlayHintsSink;
-import com.intellij.codeInsight.hints.NoSettings;
 import com.intellij.codeInsight.hints.SettingsKey;
 import com.intellij.lang.Language;
 import com.intellij.lang.java.JavaLanguage;
@@ -16,22 +16,23 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class EnumOrdinalHintProvider implements InlayHintsProvider<NoSettings> {
+
+public class EnumOrdinalHintProvider implements InlayHintsProvider<EnumOrdinalSettingsState> {
 
 	private static final String NAME = "Inlay enum ordinals";
 	private static final String PREVIEW_TEXT = "Enum ordinals, inlay for the inLAY-Z.";
-	private static final String SETTINGS_KEY = "com.github.umbreon22.inlay-enum-ordinals";
+	private static final SettingsKey<EnumOrdinalSettingsState> SETTINGS_KEY = new SettingsKey<>("com.github.umbreon22.inlay-enum-ordinals");
 
 	@Nullable
 	@Override
-	public InlayHintsCollector getCollectorFor(@NotNull PsiFile psiFile, @NotNull Editor editor, @NotNull NoSettings settings, @NotNull InlayHintsSink inlayHintsSink) {
-		return new EnumOrdinalHintCollector(editor);
+	public InlayHintsCollector getCollectorFor(@NotNull PsiFile psiFile, @NotNull Editor editor, @NotNull EnumOrdinalSettingsState settings, @NotNull InlayHintsSink inlayHintsSink) {
+		return new EnumOrdinalHintCollector(editor, settings);
 	}
 
 	@NotNull
 	@Override
-	public NoSettings createSettings() {
-		return new NoSettings();
+	public EnumOrdinalSettingsState createSettings() {
+		return EnumOrdinalSettingsState.getInstance();
 	}
 
 	@Nls(capitalization = Nls.Capitalization.Sentence)
@@ -43,8 +44,8 @@ public class EnumOrdinalHintProvider implements InlayHintsProvider<NoSettings> {
 
 	@NotNull
 	@Override
-	public SettingsKey<NoSettings> getKey() {
-		return new SettingsKey<>(SETTINGS_KEY);
+	public SettingsKey<EnumOrdinalSettingsState> getKey() {
+		return SETTINGS_KEY;
 	}
 
 	@Nullable
@@ -55,7 +56,7 @@ public class EnumOrdinalHintProvider implements InlayHintsProvider<NoSettings> {
 
 	@NotNull
 	@Override
-	public ImmediateConfigurable createConfigurable(@NotNull NoSettings settings) {
+	public ImmediateConfigurable createConfigurable(@NotNull EnumOrdinalSettingsState settings) {
 		return changeListener -> new JPanel();
 	}
 

--- a/src/main/java/com.github.umbreon22.inlayenumordinals/PsiEnumUtil.java
+++ b/src/main/java/com.github.umbreon22.inlayenumordinals/PsiEnumUtil.java
@@ -1,10 +1,6 @@
 package com.github.umbreon22.inlayenumordinals;
 
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiEnumConstant;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiReferenceExpression;
+import com.intellij.psi.*;
 
 final class PsiEnumUtil {
 
@@ -44,9 +40,14 @@ final class PsiEnumUtil {
 	/**
 	 * Determines if the {@link PsiElement} represents an enum
 	 */
-	static boolean isEnum(PsiElement element) {
+	static boolean isEnum(PsiElement element, boolean hideHintIfArguments) {
 		if(element instanceof PsiEnumConstant) {
-			return true;
+			PsiEnumConstant constant = (PsiEnumConstant) element;
+			PsiExpressionList argList = constant.getArgumentList();
+			if(argList == null) {
+				return true;
+			}
+			return !hideHintIfArguments || argList.isEmpty();
 		} else if(element instanceof PsiReferenceExpression) {
 			PsiReferenceExpression expr = ((PsiReferenceExpression) element);
 			PsiElement resolved = expr.resolve();

--- a/src/main/java/com.github.umbreon22.inlayenumordinals/PsiEnumUtil.java
+++ b/src/main/java/com.github.umbreon22.inlayenumordinals/PsiEnumUtil.java
@@ -40,21 +40,28 @@ final class PsiEnumUtil {
 	/**
 	 * Determines if the {@link PsiElement} represents an enum
 	 */
-	static boolean isEnum(PsiElement element, boolean hideHintIfArguments) {
-		if(element instanceof PsiEnumConstant) {
-			PsiEnumConstant constant = (PsiEnumConstant) element;
-			PsiExpressionList argList = constant.getArgumentList();
-			if(argList == null) {
-				return true;
-			}
-			return !hideHintIfArguments || argList.isEmpty();
-		} else if(element instanceof PsiReferenceExpression) {
+	static boolean isEnum(PsiElement element) {
+		return element instanceof PsiEnumConstant;
+	}
+
+	/**
+	 * Determines if the {@link PsiElement} represents an enum reference
+	 */
+	static boolean isEnumReference(PsiElement element) {
+		if(element instanceof PsiReferenceExpression) {
 			PsiReferenceExpression expr = ((PsiReferenceExpression) element);
 			PsiElement resolved = expr.resolve();
 			return resolved instanceof PsiEnumConstant;
 		} else {
 			return false;
 		}
+	}
+	/**
+	 * Determines if the {@link PsiEnumConstant} has any arguments
+	 */
+	static boolean hasArguments(PsiEnumConstant constant) {
+		PsiExpressionList argList = constant.getArgumentList();
+		return argList == null || argList.isEmpty();
 	}
 
 }

--- a/src/main/java/com/github/umbreon22/inlayenumordinals/settings/EnumOrdinalConfigurable.java
+++ b/src/main/java/com/github/umbreon22/inlayenumordinals/settings/EnumOrdinalConfigurable.java
@@ -1,0 +1,62 @@
+package com.github.umbreon22.inlayenumordinals.settings;
+
+
+import com.github.umbreon22.inlayenumordinals.settings.ui.EnumOrdinalSettingsForm;
+import com.intellij.openapi.options.SearchableConfigurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class EnumOrdinalConfigurable implements SearchableConfigurable {
+
+	private EnumOrdinalSettingsForm settingsPane;
+
+	@Override
+	public @NotNull String getId() {
+		return "com.github.umbreon22.inlayenumordinals.settings.EnumOrdinalConfigurable";
+	}
+
+	@Nls(capitalization = Nls.Capitalization.Title)
+	@Override
+	public String getDisplayName() {
+		return "InlayEnumOrdinals";
+	}
+
+	@Override
+	public JComponent getPreferredFocusedComponent() {
+		return settingsPane.getPreferredFocusedComponent();
+	}
+
+	@Override
+	public @Nullable JComponent createComponent() {
+		if(settingsPane == null){
+			settingsPane = new EnumOrdinalSettingsForm();
+		}
+		return settingsPane.getPanel();
+	}
+
+	@Override
+	public boolean isModified() {
+		EnumOrdinalSettingsState settings = EnumOrdinalSettingsState.getInstance();
+		return settingsPane != null && settingsPane.getHideHintIfArguments() != settings.getHideHintIfArguments();
+	}
+
+	@Override
+	public void apply() {
+		EnumOrdinalSettingsState settings = EnumOrdinalSettingsState.getInstance();
+		settings.setHideHintIfArguments(settingsPane.getHideHintIfArguments());
+	}
+
+	@Override
+	public void reset() {
+		EnumOrdinalSettingsState settings = EnumOrdinalSettingsState.getInstance();
+		settingsPane.setHideHintIfArguments(settings.getHideHintIfArguments());
+	}
+
+	@Override
+	public void disposeUIResources() {
+		settingsPane = null;
+	}
+}

--- a/src/main/java/com/github/umbreon22/inlayenumordinals/settings/EnumOrdinalSettingsState.java
+++ b/src/main/java/com/github/umbreon22/inlayenumordinals/settings/EnumOrdinalSettingsState.java
@@ -1,0 +1,44 @@
+package com.github.umbreon22.inlayenumordinals.settings;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+
+@State(
+		name = "EnumOrdinalSettings",
+		storages = {
+				@Storage("/EnumOrdinalSettingsPlugin.xml")
+		}
+)
+public class EnumOrdinalSettingsState implements PersistentStateComponent<EnumOrdinalSettingsState> {
+
+	private boolean hideHintIfArguments;
+
+	public static EnumOrdinalSettingsState getInstance() {
+		return ServiceManager.getService(EnumOrdinalSettingsState.class);
+	}
+
+	@Override
+	@Nullable
+	public EnumOrdinalSettingsState getState() {
+		return this;
+	}
+
+	@Override
+	public void loadState(@NotNull EnumOrdinalSettingsState state) {
+		XmlSerializerUtil.copyBean(state, this);
+	}
+
+	public boolean getHideHintIfArguments() {
+		return hideHintIfArguments;
+	}
+
+	public void setHideHintIfArguments(boolean hideHintIfArguments) {
+		this.hideHintIfArguments = hideHintIfArguments;
+	}
+}

--- a/src/main/java/com/github/umbreon22/inlayenumordinals/settings/ui/EnumOrdinalSettingsForm.form
+++ b/src/main/java/com/github/umbreon22/inlayenumordinals/settings/ui/EnumOrdinalSettingsForm.form
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.github.umbreon22.inlayenumordinals.settings.ui.EnumOrdinalSettingsForm">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="82961" class="javax.swing.JCheckBox" binding="hideHintIfArgumentsCheckBox">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Hide Hint if Arguments are provided"/>
+        </properties>
+      </component>
+      <hspacer id="55da2">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
+      <vspacer id="6f0a3">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/com/github/umbreon22/inlayenumordinals/settings/ui/EnumOrdinalSettingsForm.java
+++ b/src/main/java/com/github/umbreon22/inlayenumordinals/settings/ui/EnumOrdinalSettingsForm.java
@@ -1,0 +1,29 @@
+package com.github.umbreon22.inlayenumordinals.settings.ui;
+
+import javax.swing.*;
+
+/**
+ * @author Arnah
+ * @since Jun 06, 2021
+ **/
+public class EnumOrdinalSettingsForm {
+
+	private JCheckBox hideHintIfArgumentsCheckBox;
+	private JPanel panel;
+
+	public JPanel getPanel() {
+		return panel;
+	}
+
+	public boolean getHideHintIfArguments() {
+		return hideHintIfArgumentsCheckBox.isSelected();
+	}
+
+	public void setHideHintIfArguments(boolean hideHintIfArguments) {
+		hideHintIfArgumentsCheckBox.setSelected(hideHintIfArguments);
+	}
+
+	public JComponent getPreferredFocusedComponent() {
+		return hideHintIfArgumentsCheckBox;
+	}
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,5 +9,8 @@
     <depends>com.intellij.java</depends>
     <extensions defaultExtensionNs="com.intellij">
         <codeInsight.inlayProvider language="JAVA" implementationClass="com.github.umbreon22.inlayenumordinals.EnumOrdinalHintProvider"/>
+        <applicationService serviceImplementation="com.github.umbreon22.inlayenumordinals.settings.EnumOrdinalSettingsState"/>
+        <projectConfigurable instance="com.github.umbreon22.inlayenumordinals.settings.EnumOrdinalConfigurable"
+                             id="com.github.umbreon22.EnumOrdinalSettings" displayName="Inlay Enum Ordinal Settings" nonDefaultProject="true"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
This adds a category to the Settings ui. I opted for this type of settings ui despite inlay hints having a special config setup because it seems to require kotlin for handling "Cases" while also being unable to find any good documentation for alternatives.

Not entirely sure if how I handle this via getting the bool to isEnum is the best way but it was the easiest.

Most of this is referenced from https://plugins.jetbrains.com/docs/intellij/settings-guide.html and a couple other github projects.

Visual of what happens when Hint hiding if arguments are provided is enabled.
![java_6eWdbnqreQ](https://user-images.githubusercontent.com/2877803/120960244-a5d0d000-c718-11eb-937b-95bf4e61b885.png)
