### PR TITLE
Update IDE versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -90,12 +90,12 @@ jobs:
       artifact: ${{ steps.properties.outputs.artifact }}
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -153,12 +153,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 111 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,19 @@
 
 pluginGroup = com.github.umbreon22.inlayenumordinals
 pluginName = inlay-enum-ordinals
-pluginVersion = 1.0.0
+pluginVersion = 1.0.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 202
-pluginUntilBuild = 211.*
+pluginUntilBuild = 213.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.1
+pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.3, 2021.2.2
 
 platformType = IC
-platformVersion = 2020.2.4
+platformVersion = 2021.2.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION
Bumps plugin version to 1.0.1
Updates `pluginUntilBuild` to 213(2021.3)
Update `pluginVerifierIdeVersions` 2021.1 to latest version and adds 2021.2.2
Update `platformVersion` to 2021.2.2

I personally tested it on 2021.3 EAP and 2021.2.2 sandbox

1 thing to note is https://github.com/umbreon22/inlay-enum-ordinals/blob/main/src/main/java/com/github/umbreon22/inlayenumordinals/EnumOrdinalHintCollector.java#L61 being deprecated and suggesting for a `false` to be added as the last arg. I'm not entirely sure if doing this will break backwards compatibility but this method still existing in 2021.3 is due to backwards compatibility support as seen here https://youtrack.jetbrains.com/issue/IDEA-248287